### PR TITLE
fix theme on titles

### DIFF
--- a/lib/components/eachPaperCard.dart
+++ b/lib/components/eachPaperCard.dart
@@ -163,6 +163,11 @@ class _EachPaperCardState extends State<EachPaperCard> {
                       child: TeXViewDocument(
                         title,
                         style: TeXViewStyle(
+                          contentColor: ThemeProvider.themeOf(context)
+                              .data
+                              .textTheme
+                              .bodyLarge
+                              ?.color,
                           textAlign: TeXViewTextAlign.left,
                           fontStyle: TeXViewFontStyle(
                               fontSize: 16, fontWeight: TeXViewFontWeight.bold),


### PR DESCRIPTION
Hi, 
Sorry about this... Forgot to check theming on titles 😅 :
![image](https://github.com/user-attachments/assets/fb685042-a57d-453d-9b0b-e7dff7ff2368)

However this only happens with dark mode